### PR TITLE
cyclic_deque from view to container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake)
 project(ouroboros
     LANGUAGES CXX
     VERSION 0.1.0
-    DESCRIPTION "Ouroboros is a C++ header only library containing a cyclic deque, aka a circular buffer, that provides a cyclic view of a contiguous sequence."
+    DESCRIPTION "Ouroboros is a C++ header only library containing a cyclic deque, aka a circular buffer, that supports fast insertion and deletion at both its beginning and end."
     HOMEPAGE_URL "https://github.com/Jaybro/ouroboros")
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build-and-test](https://github.com/Jaybro/ouroboros/workflows/build-and-test/badge.svg)](https://github.com/Jaybro/ouroboros/actions?query=workflow%3Abuild-and-test)
 
-Ouroboros is a C++ header only library containing a cyclic deque, otherwise known as a [circular buffer](https://en.wikipedia.org/wiki/Circular_buffer), ring buffer, etc. The cyclic deque, named `ouroboros::cyclic_deque<>`, describes an object that provides a circular view of a contiguous sequence of objects with the first element of the sequence at position zero. A deque (double-ended queue) allows fast insertion and deletion at both its beginning and end.
+Ouroboros is a C++ header only library containing a cyclic deque, otherwise known as a [circular buffer](https://en.wikipedia.org/wiki/Circular_buffer), ring buffer, etc. The cyclic deque, named `ouroboros::cyclic_deque<>`, describes a sequence container with the first and last element of the sequence seemingly connected end-to-end. A deque (double-ended queue) allows fast insertion and deletion at both its beginning and end.
 
 The library is named after the [symbol](https://en.wikipedia.org/wiki/Ouroboros) depicting a serpent or dragon that eats its own tail and it represents the infinite amount of times a circular buffer has been implemented in code throughout history.
 
@@ -10,7 +10,7 @@ Available under the [MIT](https://en.wikipedia.org/wiki/MIT_License) license.
 
 # Capabilities
 
-* Interpret any contiguous sequence as a cyclic deque.
+* The capacity of the container can be set at run-time.
 * Fast insertion and deletion at both its beginning and end.
 * STL compliant. Provides the interface of a random access range.
 

--- a/examples/cyclic_deque/cyclic_deque_minimal.cpp
+++ b/examples/cyclic_deque/cyclic_deque_minimal.cpp
@@ -15,13 +15,10 @@ void Print(Range_ const& range, std::string const& name) {
 }
 
 int main() {
-  BufferItem buffer[] = {{-1}, {-1}, {-1}, {-1}};
-
-  ouroboros::cyclic_deque ring(buffer);
+  ouroboros::cyclic_deque<BufferItem> ring(4);
   ring.push_back({41});
   ring.push_front({42});
 
-  Print(buffer, "buffer");
   Print(ring, "ring");
 
   return 0;

--- a/test/cyclic_deque_test.cpp
+++ b/test/cyclic_deque_test.cpp
@@ -44,6 +44,17 @@ TEST(CyclicDequeTest, ConstructorCapacitySize) {
   ExpectCapacityAndSize(cdeque, capacity, size);
 }
 
+TEST(CyclicDequeTest, ConstructorIterators) {
+  std::vector<std::size_t> v(10, 42);
+  ouroboros::cyclic_deque cdeque(v.begin(), v.end());
+  ExpectCapacityAndSize(cdeque, v.size(), v.size());
+}
+
+TEST(CyclicDequeTest, ConstructorInitializerList) {
+  ouroboros::cyclic_deque cdeque({42.0f, 42.0f, 42.0f, 42.0f});
+  ExpectCapacityAndSize(cdeque, 4, 4);
+}
+
 TEST(CyclicDequeTest, FullEmptyClear) {
   std::size_t capacity = 8;
   ouroboros::cyclic_deque<std::size_t> cdeque(capacity, capacity);


### PR DESCRIPTION
Refactored the cyclic_deque to be a sequence container instead of a view. This makes it usable in more settings and easier to use, without having to deal with common pitfalls that follow from creating a view on external buffers. Perhaps a `cyclic_deque_view` will be introduced in the future if that seems useful.

Changes:
* `cyclic_deque ` is now a sequence container instead of a view.
* Added const vs. non-const iterator operators.
* Iterator constexpr and noexcept improvements.
* Moved various methods to cyclic_deque_impl.
* Fixed `resize()`.
* Added `allocator_type` typedef.
* Documentation updated.